### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ericclute


### PR DESCRIPTION
<!-- generated-by: psrc-codeowners-rollout -->

Add a default CODEOWNERS file for this repository based on the initial ownership rollout list.

Default codeowner: @ericclute

The generated file contains:

```text
* @ericclute
```

After merge, the repository owner can expand the CODEOWNERS rules or transfer ownership as needed.
